### PR TITLE
refs platform#3617: fix cleanup policies validation

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -72,14 +72,7 @@ variable "repositories" {
   validation {
     condition = alltrue([
       for policy in flatten([for repo in var.repositories : [for cp in repo.cleanup_policies : cp]]) : 
-        try(
-          policy.most_recent_versions == {} || 
-          (
-            can(policy.most_recent_versions.keep_count) && 
-            (policy.most_recent_versions.keep_count == null || policy.most_recent_versions.keep_count > 0)
-          ), 
-          true
-        )
+        policy.most_recent_versions == {} || try((policy.most_recent_versions.keep_count == null || policy.most_recent_versions.keep_count > 0), true)
     ])
     error_message = "Keep count must be a non-negative number and greater than zero if specified."
   }

--- a/variables.tf
+++ b/variables.tf
@@ -74,7 +74,7 @@ variable "repositories" {
       for policy in flatten([for repo in var.repositories : [for cp in repo.cleanup_policies : cp]]) : 
         policy.most_recent_versions == {} || try((policy.most_recent_versions.keep_count == null || policy.most_recent_versions.keep_count > 0), true)
     ])
-    error_message = "Keep count must be a non-negative number and greater than zero if specified."
+    error_message = "Keep count must be null or greater than zero if specified."
   }
 
   validation {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix cleanup policies validation for `keep_count` parameter

- Change default value from undefined to `null`

- Add proper validation logic with error handling

- Update error message for clarity


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>variables.tf</strong><dd><code>Fix keep_count validation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

variables.tf

<li>Changed <code>keep_count</code> default from undefined to <code>null</code><br> <li> Enhanced validation condition with <code>try()</code> and <code>can()</code> functions<br> <li> Updated validation to allow <code>null</code> values and require positive numbers<br> <li> Improved error message clarity


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-google-gcp-artifact-registry/pull/21/files#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288e">+13/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>