### PR TITLE
fix: merge cleanup policies

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -82,10 +82,11 @@ locals {
     for repository_id, repository in var.repositories : repository_id => merge(
       repository,
       {
-        # Merge default policies (if enabled) with custom policies
+        # Merge default policies (if enabled) with custom policies.
+        # Use a for-expression with an if filter to avoid inconsistent conditional object types.
         cleanup_policies = merge(
-          repository.cleanup_policies_enable_default ? local.cleanup_policies_default : tomap({}),
-          repository.cleanup_policies
+          repository.cleanup_policies,
+          { for k, v in local.cleanup_policies_default : k => v if repository.cleanup_policies_enable_default }
         )
       }
     )

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,8 +17,3 @@ output "custom_role_artifact_registry_lister_id" {
   value       = length(var.artifact_registry_listers) > 0 ? local.custom_role_artifact_registry_lister_id : null
   description = "The ID of the custom role for Artifact Registry listers. The role is created only if the list of Artifact Registry listers is not empty."
 }
-
-output "repositories_configurations" {
-  value = local.repositories_final
-  description = "The final configuration of the Artifact Registry repositories after merging with defaults."
-}

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,3 +17,8 @@ output "custom_role_artifact_registry_lister_id" {
   value       = length(var.artifact_registry_listers) > 0 ? local.custom_role_artifact_registry_lister_id : null
   description = "The ID of the custom role for Artifact Registry listers. The role is created only if the list of Artifact Registry listers is not empty."
 }
+
+output "repositories_configurations" {
+  value = local.repositories_final
+  description = "The final configuration of the Artifact Registry repositories after merging with defaults."
+}


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Simplified cleanup policies merge logic by removing `tomap()` wrapper

- Added output for final repository configurations after defaults merge


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Repository Config"] --> B["Merge Cleanup Policies"]
  B --> C["Final Repository Config"]
  C --> D["New Output"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Simplify cleanup policies merge logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

main.tf

<ul><li>Simplified cleanup policies merge by removing unnecessary <code>tomap({})</code> <br>conversion<br> <li> Changed empty map fallback from <code>tomap({})</code> to <code>{}</code> for cleaner syntax</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-google-gcp-artifact-registry/pull/24/files#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbb">+1/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>outputs.tf</strong><dd><code>Add repositories final configuration output</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

outputs.tf

<ul><li>Added new output <code>repositories_configurations</code> exposing final repository <br>configurations<br> <li> Output includes merged cleanup policies and defaults for <br>debugging/validation</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-google-gcp-artifact-registry/pull/24/files#diff-de6c47c2496bd028a84d55ab12d8a4f90174ebfb6544b8b5c7b07a7ee4f27ec7">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

